### PR TITLE
feat: audit feedback

### DIFF
--- a/burner/.gitignore
+++ b/burner/.gitignore
@@ -4,4 +4,4 @@ build
 .DS_Store
 node_modules
 artifacts
-cache 
+cache

--- a/burner/cache/path-to-last-config-used.txt
+++ b/burner/cache/path-to-last-config-used.txt
@@ -1,1 +1,0 @@
-/Users/imazzara/Documents/decentraland/aux-contracts/burner/buidler.config.js

--- a/burner/contracts/DecentralandBurner.sol
+++ b/burner/contracts/DecentralandBurner.sol
@@ -30,26 +30,27 @@ contract DecentralandBurner is Ownable {
     * @param _data - bytes for the msg.data.
     * @return response - bytes for the call response.
     */
-    function execute(address payable _target, bytes calldata _data) 
-    external 
-    payable 
-    onlyOwner 
+    function execute(address payable _target, bytes calldata _data)
+    external
+    payable
+    onlyOwner
     returns (bytes memory)
     {
+        require(_target != address(mana), "The target should not be the MANA contract");
         // solium-disable-next-line security/no-call-value
         (bool success, bytes memory response) = _target.call.value(msg.value)(_data);
 
         if (!success) {
             revert("Call error");
         }
-        
+
         emit Executed(_target, _data);
 
         return response;
     }
 
     /**
-    * @dev Burn MANA owned by this contract 
+    * @dev Burn MANA owned by this contract
     */
     function burn() external {
         mana.burn(mana.balanceOf(address(this)));

--- a/burner/test/DecentralandBurner.spec.js
+++ b/burner/test/DecentralandBurner.spec.js
@@ -160,12 +160,12 @@ describe('DecentralandBurner', function() {
     })
 
     it('reverts if call is not a success', async function() {
-      const data = await manaContract.contract.methods
-        .mint(owner, INITIAL_VALUE)
+      const data = await erc721Contract.contract.methods
+        .mint(owner, 1)
         .encodeABI()
 
       await assertRevert(
-        burnerContract.execute(manaContract.address, data, fromOwner),
+        burnerContract.execute(erc721Contract.address, data, fromOwner),
         'Call error'
       )
     })
@@ -184,6 +184,17 @@ describe('DecentralandBurner', function() {
     it('reverts if not owner wants to execute', async function() {
       await assertRevert(
         burnerContract.execute(marketplaceContract.address, '0x')
+      )
+    })
+
+    it('reverts if target is MANA contract', async function() {
+      const data = await manaContract.contract.methods
+        .mint(owner, INITIAL_VALUE)
+        .encodeABI()
+
+      await assertRevert(
+        burnerContract.execute(manaContract.address, data, fromOwner),
+        'The target should not be the MANA contract'
       )
     })
   })


### PR DESCRIPTION
Based on the audit

```
The owner of the burner contract could choose to withdraw the MANA tokens without calling
the burn() method.
Proposed Solution:
Internally call burn() before executing any command using execute()
```